### PR TITLE
Dev

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,6 +26,8 @@ jobs:
     name: Build for Raspberry Pi 4 (aarch64)
     runs-on: ubuntu-latest
     steps:
+      - name: Install OpenSSL
+        run: sudo apt-get update && sudo apt-get install -y libssl-dev
       - uses: actions/checkout@v4
       - name: Install cross
         run: cargo install cross --git https://github.com/cross-rs/cross

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Run tests
         run: cargo test --verbose
 
-  build-pi4:
+  build-rpi4:
     name: Build for Raspberry Pi 4 (aarch64)
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - name: Install OpenSSL
         run: sudo apt-get update && sudo apt-get install -y libssl-dev
-      - uses: actions/checkout@v4
       - name: Install cross
         run: cargo install cross --git https://github.com/cross-rs/cross
       - name: Build (aarch64-unknown-linux-gnu)
@@ -41,7 +41,7 @@ jobs:
 
   release:
     name: Release
-    needs: build-pi4
+    needs: build-rpi4
     runs-on: ubuntu-latest
     if: github.event_name == 'release'
     steps:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for Rust projects to improve compatibility and clarity. The most important changes involve renaming a job for consistency and adding a dependency installation step.

### Workflow improvements:

* Renamed the job `build-pi4` to `build-rpi4` for better clarity and consistency. This change is reflected in both the job definition and the `needs` dependency in the `release` job. (`.github/workflows/rust.yml`, [[1]](diffhunk://#diff-73e17259d77e5fbef83b2bdbbe4dc40a912f807472287f7f45b77e0cbf78792dL25-R31) [[2]](diffhunk://#diff-73e17259d77e5fbef83b2bdbbe4dc40a912f807472287f7f45b77e0cbf78792dL42-R44)
* Added a step to install OpenSSL (`libssl-dev`) in the `build-rpi4` job to ensure compatibility during the build process. (`.github/workflows/rust.yml`, [.github/workflows/rust.ymlL25-R31](diffhunk://#diff-73e17259d77e5fbef83b2bdbbe4dc40a912f807472287f7f45b77e0cbf78792dL25-R31))