### PR TITLE
feat: set OPENSSL_DIR environment variable for Raspberry Pi 4 build

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,6 +25,8 @@ jobs:
   build-rpi4:
     name: Build for Raspberry Pi 4 (aarch64)
     runs-on: ubuntu-latest
+    env:
+      OPENSSL_DIR: /usr/local/ssl
     steps:
       - uses: actions/checkout@v4
       - name: Install OpenSSL


### PR DESCRIPTION
This pull request makes a small but important update to the `.github/workflows/rust.yml` file for the Raspberry Pi 4 build job. It introduces an environment variable to specify the OpenSSL directory.

* [`.github/workflows/rust.yml`](diffhunk://#diff-73e17259d77e5fbef83b2bdbbe4dc40a912f807472287f7f45b77e0cbf78792dR28-R29): Added `OPENSSL_DIR` environment variable to the `build-rpi4` job to ensure the correct OpenSSL directory is used during the build process.