### PR TITLE
fix: move OPENSSL_DIR environment variable to global scope in GitHub …

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,6 +11,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  OPENSSL_DIR: /usr/local/ssl
 
 jobs:
   build:
@@ -25,8 +26,6 @@ jobs:
   build-rpi4:
     name: Build for Raspberry Pi 4 (aarch64)
     runs-on: ubuntu-latest
-    env:
-      OPENSSL_DIR: /usr/local/ssl
     steps:
       - uses: actions/checkout@v4
       - name: Install OpenSSL


### PR DESCRIPTION
This pull request updates the `.github/workflows/rust.yml` file to streamline environment variable management for the OpenSSL directory. The most important changes include moving the `OPENSSL_DIR` environment variable to a global scope and removing its redundant declaration in a specific job.

Workflow improvements:

* [`.github/workflows/rust.yml`](diffhunk://#diff-73e17259d77e5fbef83b2bdbbe4dc40a912f807472287f7f45b77e0cbf78792dR14): Added `OPENSSL_DIR` as a global environment variable under the `env` section to ensure it is available across all jobs.
* [`.github/workflows/rust.yml`](diffhunk://#diff-73e17259d77e5fbef83b2bdbbe4dc40a912f807472287f7f45b77e0cbf78792dL28-L29): Removed the redundant `OPENSSL_DIR` declaration from the `build-rpi4` job since it is now defined globally.…Actions workflow