### PR TITLE
fix: update OPENSSL_DIR environment variable to correct path in GitHu…

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  OPENSSL_DIR: /usr/local/ssl
+  OPENSSL_DIR: /usr/bin/openssl
 
 jobs:
   build:


### PR DESCRIPTION
This pull request includes a small update to the `.github/workflows/rust.yml` file. The change modifies the `OPENSSL_DIR` environment variable to point to `/usr/bin/openssl` instead of `/usr/local/ssl`.…b Actions workflow