### PR TITLE
fix: update OpenSSL installation step and artifact naming in GitHub A…

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  OPENSSL_DIR: /usr/bin/openssl
 
 jobs:
   build:
@@ -28,16 +27,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-hack,cargo-minimal-versions
       - name: Install OpenSSL
-        run: sudo apt-get update && sudo apt-get install -y libssl-dev
-      - name: Install cross
-        run: cargo install cross --git https://github.com/cross-rs/cross
+        run: sudo apt-get update && sudo apt-get install -y libssl-dev openssl
+      # - name: Install cross
+      #   run: cargo install cross --git https://github.com/cross-rs/cross
       - name: Build (aarch64-unknown-linux-gnu)
         run: cross build --release --target aarch64-unknown-linux-gnu
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: dyncf-pi4
+          name: dyncf-rpi4
           path: target/aarch64-unknown-linux-gnu/release/dyncf
 
   release:
@@ -50,7 +52,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
-          name: dyncf-pi4
+          name: dyncf-rpi4
           path: ./release-assets
       - name: Generate changelog
         uses: heinrichreimer/github-changelog-generator-action@v2.3


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for the Rust project to improve dependency management, streamline the build process, and align artifact naming conventions. The most important changes are grouped below.

### Dependency Management and Build Process:

* Removed the `OPENSSL_DIR` environment variable, as it is no longer needed. (`.github/workflows/rust.yml`)
* Added the `taiki-e/install-action@v2` action to install `cargo-hack` and `cargo-minimal-versions` for enhanced Cargo dependency testing. (`.github/workflows/rust.yml`)
* Updated the OpenSSL installation step to include the `openssl` package alongside `libssl-dev`. (`.github/workflows/rust.yml`)
* Commented out the `cross` installation step, likely due to redundancy or a shift in the build strategy. (`.github/workflows/rust.yml`)

### Artifact Naming:

* Renamed the artifact from `dyncf-pi4` to `dyncf-rpi4` to standardize naming conventions. (`.github/workflows/rust.yml`) [[1]](diffhunk://#diff-73e17259d77e5fbef83b2bdbbe4dc40a912f807472287f7f45b77e0cbf78792dR30-R42) [[2]](diffhunk://#diff-73e17259d77e5fbef83b2bdbbe4dc40a912f807472287f7f45b77e0cbf78792dL53-R55)…ctions workflow