### PR TITLE
fix: streamline OpenSSL installation in GitHub Actions workflow and a…

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           tool: cross
       - name: Installs OpenSSL...
-        run: sudo apt-get update && sudo apt-get upgrade -y && sudo apt-get install -y libssl-dev pkg-config
+        run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config
       # - name: Install cross
       #   run: cargo install cross --git https://github.com/cross-rs/cross
       - name: Build (aarch64-unknown-linux-gnu)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,6 +157,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "dotenv",
+ "openssl",
  "reqwest",
  "serde",
  "serde_json",
@@ -734,6 +735,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
+name = "openssl-src"
+version = "300.5.0+3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8ce546f549326b0e6052b649198487d91320875da901e7bd11a06d1ee3f9c2f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -741,6 +751,7 @@ checksum = "e145e1651e858e820e4860f7b9c5e169bc1d8ce1c86043be79fa7b7634821847"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 repository = "https://github.com/yourusername/dyncf"
 
 [dependencies]
+openssl = { version = "0.10.29", features = ["vendored"] }
 reqwest = { version = "0.12.15", features = ["json", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly TARGET_HOST=pablushka@coolify.nomades.ar
+readonly TARGET_ARCH=armv7-unknown-linux-gnueabihf
+# readonly TARGET_ARCH=armv7-unknown-linux-gnueabihf
+readonly TARGET_PATH=/home/pablushka
+readonly SOURCE_PATH=./target/${TARGET_ARCH}/release/dyncf
+
+cargo build --release --target=${TARGET_ARCH}
+
+#rsync ${SOURCE_PATH} ${TARGET_HOST}:${TARGET_PATH}
+
+#ssh -t ${TARGET_HOST} ${TARGET_PATH}


### PR DESCRIPTION
This pull request includes updates to the build process, dependencies, and deployment script to streamline development and deployment workflows. The most important changes include removing unnecessary steps in the GitHub Actions workflow, adding a new dependency with specific features in `Cargo.toml`, and introducing a new deployment script.

### Build process improvements:
* [`.github/workflows/rust.yml`](diffhunk://#diff-73e17259d77e5fbef83b2bdbbe4dc40a912f807472287f7f45b77e0cbf78792dL34-R34): Removed the `sudo apt-get upgrade` command from the OpenSSL installation step in the GitHub Actions workflow to reduce unnecessary updates during CI runs.

### Dependency updates:
* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R12): Added the `openssl` crate with version `0.10.29` and the `vendored` feature to ensure compatibility with the OpenSSL library.

### Deployment enhancements:
* [`deploy.sh`](diffhunk://#diff-30883d1df2fc62f59d66255a70dc05f60d3d4ef4d3957e6e3e38e62f6e471bd0R1-R18): Introduced a new deployment script that builds the project for the `armv7-unknown-linux-gnueabihf` target architecture and sets up environment variables for deployment. The script includes commented-out commands for `rsync` and `ssh` to facilitate deployment to a remote host.…dd openssl dependency in Cargo.toml